### PR TITLE
Generate issue

### DIFF
--- a/FemtoRV/FIRMWARE/EXAMPLES/sieve.c
+++ b/FemtoRV/FIRMWARE/EXAMPLES/sieve.c
@@ -72,7 +72,10 @@ int main(void)
 	*/
         femtosoc_tty_init();
 
-	int idx = 1;
+	int idx;
+
+start:
+	idx = 1;
 	hash = 5381;
 	print_prime(idx++, 2);
 	for (int i = 0; i < BITMAP_SIZE; i++) {
@@ -98,8 +101,11 @@ int main(void)
 	        printf(" OK\n");
 	} else {
 		printf(" ERROR\n");
-		abort();
 	}
+
+   delay(1000);
+   goto start;  // loop forever
+
    return 0;
 }
 

--- a/FemtoRV/FIRMWARE/LIBFEMTORV32/wait_cycles.S
+++ b/FemtoRV/FIRMWARE/LIBFEMTORV32/wait_cycles.S
@@ -1,0 +1,18 @@
+.include "femtorv32.inc"
+
+#################################################################################
+
+.global	wait_cycles
+.type	wait_cycles, @function
+
+# \brief wait a number of cycles
+# \param a0 number of cycles to wait
+wait_cycles:
+        li   t0, IO_HW_CONFIG_CPUINFO # read CPUINFO HW-config 
+        add  t0, t0, gp
+	lw   t0, 0(t0)                    
+	srli t0, t0, 26               # extract CPL (Cycles per Loop)
+.L1:	sub  a0, a0, t0
+        bge  a0, zero, .L1
+	ret
+	

--- a/FemtoRV/RTL/DEVICES/SSD1351_1331.v
+++ b/FemtoRV/RTL/DEVICES/SSD1351_1331.v
@@ -55,6 +55,11 @@ module SSD1351(
    //   experimentally, seems to work up to 30 Mhz (but not more)
    
    // Seems that iverilog and verilator do not like the way I'm using 'generate' below.
+   // Because: Variables declared within a generate scope
+   //          are local to that generate scope.
+   // Then Verilog compiler issues "ERROR: Identifier is implicitly declared"
+   // whenever you'll use one of the parameters declared in the 'generate' block.
+ `define BENCH_OR_LINT  // TODO this is only a temporary fix
  `ifdef BENCH_OR_LINT
    reg[1:0] slow_cnt;
    localparam cnt_bit = 1;

--- a/FemtoRV/RTL/PLL/gen_pll.sh
+++ b/FemtoRV/RTL/PLL/gen_pll.sh
@@ -47,9 +47,9 @@ EOF
       .FEEDBACK_PATH("SIMPLE"),
       .PLLOUT_SELECT("GENCLK"),
       .DIVR(4'b0000),
-      .DIVF(DIVF), 
-      .DIVQ(DIVQ), 
-      .FILTER_RANGE(FILTER_RANGE),
+      .DIVF(7'b0000000), 
+      .DIVQ(3'b000), 
+      .FILTER_RANGE(3'b000),
    ) pll (
       .REFERENCECLK(pclk),
       .PLLOUTCORE(clk),

--- a/FemtoRV/RTL/PLL/pll_icestick.v
+++ b/FemtoRV/RTL/PLL/pll_icestick.v
@@ -194,9 +194,9 @@
       .FEEDBACK_PATH("SIMPLE"),
       .PLLOUT_SELECT("GENCLK"),
       .DIVR(4'b0000),
-      .DIVF(DIVF), 
-      .DIVQ(DIVQ), 
-      .FILTER_RANGE(FILTER_RANGE),
+      .DIVF(7'b0000000), 
+      .DIVQ(3'b000), 
+      .FILTER_RANGE(3'b000),
    ) pll (
       .REFERENCECLK(pclk),
       .PLLOUTCORE(clk),

--- a/FemtoRV/TUTORIALS/toolchain.md
+++ b/FemtoRV/TUTORIALS/toolchain.md
@@ -135,6 +135,8 @@ Follow setup instructions from [nextpnr website](https://github.com/YosysHQ/next
 Get the sources:
 ```
 $ git clone https://github.com/YosysHQ/nextpnr.git
+$ cd nextpnr
+$ git submodule update --init --recursive
 ```
 
 NextPNR compilation and installation for Ice40 FPGAs


### PR DESCRIPTION
Hello Bruno,

First of all, many thanks for your great job.

I had issues generating the bitstream for IceStick ICE40HX1K that I fixed in the following way.

My devices configuration icestick_config.v file:

`define NRV_IO_LEDS          // Mapped IO, LEDs D1,D2,D3,D4 (D5 is used to display errors)
//`define NRV_IO_IRDA          // In IO_LEDS, support for the IRDA on the IceStick (WIP)
`define NRV_IO_UART          // Mapped IO, virtual UART (USB)
//`define NRV_IO_SSD1351       // Mapped IO, 128x128x64K OLED screen
//`define NRV_IO_MAX7219       // Mapped IO, 8x8 led matrix
`define NRV_MAPPED_SPI_FLASH // SPI flash mapped in address space. Use with MINIRV32 to run code from SPI flash.

I kept the remainder the same.

Toolchain:

Yosys 0.9
Icarus Verilog version 10.3 (stable)
Verilator 4.028 

Issue #1. ERROR: Identifier xxx is implicitly declared

To let the synthesis continue, I had to declare them in some way.
I state that I'm new in FPGA design and Verilog coding, then I'm not sure to had made the right things.
Particularly, in SSD1351_1331.v file.
But the synthesis completes and the bitstream works well (I don't use SSD1351 device).

Issue #2. Missing wait_cycles.S file

This file is required by the built process and I restored it from one of your previous commit.

Issue #3. sieve.c example

I added an infinite loop to see the output continuously.

Issue #4. NextPNR submodules sources

Indeed this is not an issue related to you.
Some submodule dependencies have been added to the NextPNR repository.
I suggest you to include this information in your toolchain install guide.
