### PR TITLE
Minor changes to toolchain installation instructions; Raspberry Pi and Jetson support

### DIFF
--- a/FemtoRV/FIRMWARE/makefile.inc
+++ b/FemtoRV/FIRMWARE/makefile.inc
@@ -38,10 +38,21 @@ uname_p := $(shell uname -p)
 
 ifeq ($(uname_p),aarch64)
     $(info Configuring for ARM64)
-    TOOLCHAIN_WEB=https://github.com/xpack-dev-tools/riscv-none-embed-gcc-xpack/releases/download/v10.1.0-1.1/
+    TOOLCHAIN_WEB=https://github.com/xpack-dev-tools/riscv-none-embed-gcc-xpack/releases/download/v10.1.0-1.1
     TOOLCHAIN_VER=xpack-riscv-none-embed-gcc-10.1.0-1.1
     TOOLCHAIN_DL_SUFFIX=-linux-arm64
     TOOLCHAIN_GCC_VER=10.1.0
+    RVTOOLCHAIN_BIN_PREFIX=riscv-none-embed
+endif
+
+uname_m := $(shell uname -m)
+
+ifeq ($(uname_m),armv7l)
+    $(info Configuring for Raspberry Pi)
+    TOOLCHAIN_WEB=https://github.com/xpack-dev-tools/riscv-none-embed-gcc-xpack/releases/download/v8.3.0-2.3
+    TOOLCHAIN_VER=xpack-riscv-none-embed-gcc-8.3.0-2.3
+    TOOLCHAIN_DL_SUFFIX=-linux-arm
+    TOOLCHAIN_GCC_VER=8.3.0
     RVTOOLCHAIN_BIN_PREFIX=riscv-none-embed
 endif
 

--- a/FemtoRV/FIRMWARE/makefile.inc
+++ b/FemtoRV/FIRMWARE/makefile.inc
@@ -34,9 +34,9 @@ RVTOOLCHAIN_DIR=$(FIRMWARE_DIR)/TOOLCHAIN/$(TOOLCHAIN_VER)
 RVTOOLCHAIN_BIN_DIR=$(RVTOOLCHAIN_DIR)/bin
 RVTOOLCHAIN_BIN_PREFIX=riscv64-unknown-elf
 
-uname_p := $(shell uname -p)
+uname_m := $(shell uname -m)
 
-ifeq ($(uname_p),aarch64)
+ifeq ($(uname_m),aarch64)
     $(info Configuring for ARM64)
     TOOLCHAIN_WEB=https://github.com/xpack-dev-tools/riscv-none-embed-gcc-xpack/releases/download/v10.1.0-1.1
     TOOLCHAIN_VER=xpack-riscv-none-embed-gcc-10.1.0-1.1
@@ -44,8 +44,6 @@ ifeq ($(uname_p),aarch64)
     TOOLCHAIN_GCC_VER=10.1.0
     RVTOOLCHAIN_BIN_PREFIX=riscv-none-embed
 endif
-
-uname_m := $(shell uname -m)
 
 ifeq ($(uname_m),armv7l)
     $(info Configuring for Raspberry Pi)

--- a/FemtoRV/FIRMWARE/makefile.inc
+++ b/FemtoRV/FIRMWARE/makefile.inc
@@ -32,9 +32,21 @@ TOOLCHAIN_GCC_VER=8.3.0
 
 RVTOOLCHAIN_DIR=$(FIRMWARE_DIR)/TOOLCHAIN/$(TOOLCHAIN_VER)
 RVTOOLCHAIN_BIN_DIR=$(RVTOOLCHAIN_DIR)/bin
-RVTOOLCHAIN_LIB_DIR=$(RVTOOLCHAIN_DIR)/riscv64-unknown-elf/lib/$(ARCH)/ilp32
-RVTOOLCHAIN_GCC_LIB_DIR=$(RVTOOLCHAIN_DIR)/lib/gcc/riscv64-unknown-elf/$(TOOLCHAIN_GCC_VER)/$(ARCH)/ilp32
 RVTOOLCHAIN_BIN_PREFIX=riscv64-unknown-elf
+
+uname_p := $(shell uname -p)
+
+ifeq ($(uname_p),aarch64)
+    $(info Configuring for ARM64)
+    TOOLCHAIN_WEB=https://github.com/xpack-dev-tools/riscv-none-embed-gcc-xpack/releases/download/v10.1.0-1.1/
+    TOOLCHAIN_VER=xpack-riscv-none-embed-gcc-10.1.0-1.1
+    TOOLCHAIN_DL_SUFFIX=-linux-arm64
+    TOOLCHAIN_GCC_VER=10.1.0
+    RVTOOLCHAIN_BIN_PREFIX=riscv-none-embed
+endif
+
+RVTOOLCHAIN_LIB_DIR=$(RVTOOLCHAIN_DIR)/$(RVTOOLCHAIN_BIN_PREFIX)/lib/$(ARCH)/ilp32
+RVTOOLCHAIN_GCC_LIB_DIR=$(RVTOOLCHAIN_DIR)/lib/gcc/$(RVTOOLCHAIN_BIN_PREFIX)/$(TOOLCHAIN_GCC_VER)/$(ARCH)/ilp32
 
 RVAS=$(RVTOOLCHAIN_BIN_DIR)/$(RVTOOLCHAIN_BIN_PREFIX)-as
 RVLD=$(RVTOOLCHAIN_BIN_DIR)/$(RVTOOLCHAIN_BIN_PREFIX)-ld
@@ -177,5 +189,5 @@ get_riscv_toolchain:
 	mkdir -p $(FIRMWARE_DIR)/TOOLCHAIN
 	@echo "Installing RISC-V toolchain in $(FIRMWARE_DIR)/TOOLCHAIN"
 	(cd $(FIRMWARE_DIR)/TOOLCHAIN; \
-	    wget $(TOOLCHAIN_WEB)/$(TOOLCHAIN_VER).tar.gz; \
-	    tar xfz $(TOOLCHAIN_VER).tar.gz)
+	    wget $(TOOLCHAIN_WEB)/$(TOOLCHAIN_VER)$(TOOLCHAIN_DL_SUFFIX).tar.gz; \
+	    tar xfz $(TOOLCHAIN_VER)$(TOOLCHAIN_DL_SUFFIX).tar.gz)

--- a/FemtoRV/TUTORIALS/toolchain.md
+++ b/FemtoRV/TUTORIALS/toolchain.md
@@ -69,7 +69,7 @@ compile time, and is called by `make lint` in our build system. `verilator` does
 which is vital for debugging. It is also used by the build system to transfer hardware configuration
 parameters to the firmware.
 ```
-apt-get install iverilog verilator
+sudo apt-get install iverilog verilator
 ```
 
 Step 3: FPGA support libraries
@@ -118,7 +118,7 @@ $ git clone --recursive https://github.com/YosysHQ/prjtrellis
 
 Compile and install it:
 ```
-$ cd libtrellis
+$ cd prjtrellis/libtrellis
 $ cmake -DCMAKE_INSTALL_PREFIX=/usr/local .
 $ make
 $ sudo make install
@@ -134,7 +134,7 @@ Follow setup instructions from [nextpnr website](https://github.com/YosysHQ/next
 
 Get the sources:
 ```
-$ git clone https://github.com/YosysHQ/nextpnr.git
+$ git clone --recursive https://github.com/YosysHQ/nextpnr.git
 ```
 
 NextPNR compilation and installation for Ice40 FPGAs


### PR DESCRIPTION
Added a sudo in front of an apt-get install, needed to add the prjtrellis subdirectory in the cd command, nextpnr needed recursive checkout in order for me to build.