### PR TITLE
FemtoRV/TOOLS/get_symbiflow.sh: fix env create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ FemtoRV/FIRMWARE/TOOLS/firmware_words
 FemtoRV/RTL/CONFIGS/my_config.v
 FemtoRV/femtosoc.txt
 FemtoRV/FIRMWARE/config.mk
+FemtoRV/TOOLS/environment.yml
+FemtoRV/TOOLS/requirements.txt

--- a/FemtoRV/TOOLS/get_symbiflow.sh
+++ b/FemtoRV/TOOLS/get_symbiflow.sh
@@ -5,12 +5,15 @@
 INSTALL_DIR=$HOME/opt/symbiflow
 FPGA_FAM=xc7
 ARCH_DEFS_WEB=https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/367/20210822-000315
+SYMBIFLOW_EXAMPLES=https://raw.githubusercontent.com/SymbiFlow/symbiflow-examples/master/xc7
 
 
 wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O conda_installer.sh
+wget $SYMBIFLOW_EXAMPLES/environment.yml -O environment.yml
+wget $SYMBIFLOW_EXAMPLES/requirements.txt -O requirements.txt
 bash conda_installer.sh -u -b -p $INSTALL_DIR/$FPGA_FAM/conda;
 . "$INSTALL_DIR/$FPGA_FAM/conda/etc/profile.d/conda.sh";
-$INSTALL_DIR/$FPGA_FAM/conda/bin/conda env create -f $FPGA_FAM/environment.yml
+$INSTALL_DIR/$FPGA_FAM/conda/bin/conda env create -f environment.yml
 mkdir -p $INSTALL_DIR/xc7/install
 
 echo Getting arch defs


### PR DESCRIPTION
get_symbiflow.sh is based on install instructions provided by  [symbiflow-examples](https://github.com/SymbiFlow/symbiflow-examples) repository.
By using this script an error appear with:
```
$INSTALL_DIR/$FPGA_FAM/conda/bin/conda env create -f $FPGA_FAM/environment.yml
EnvironmentFileNotFound: '/somewhere/learn-fpga/FemtoRV/TOOLS/xc7/environment.yml' file not found
```

In **getting-symbiflow.html**, the authors consider that users execute commands at the root directory of *symbiflow-examples*. So `$FPGA_FAM/environment.yml` is not a path related to `INSTALL_DIR` but to the current directory and refers to *https://github.com/SymbiFlow/symbiflow-examples/blob/master/xc7/environment.yml*

This PR add two `wget` calls: one for *environment.yml* and one for *requirements.txt* refered by the former. `conda env create` line is adjusted to use yml file located in current directory instead of xc7 subdirectory