### PR TITLE
Proof-of-concept draft: Add a simple vector extension to femtorv

### DIFF
--- a/FemtoRV/RTL/PROCESSOR/femtorv32_electron.v
+++ b/FemtoRV/RTL/PROCESSOR/femtorv32_electron.v
@@ -35,10 +35,11 @@
 //    V4 = [X16,X17,X18,X19]
 //    V5 = [X20,X21,X22,X23]
 //    V6 = [X24,X25,X26,X27]
-//    V7 = [X28,X29,X30,X31] (clobbers VL!)
+//    V7 = [X28,X29,X30,X31]
 //
-//  Furthermore, scalar register X31 maps the the VL (Vector Length)
-//  register.
+//  Furthermore the VSETVL instruction is added, using the same
+//  encoding and definition as in the V extension, except that the
+//  rs2 operand (vtype setting) is ignored.
 /*******************************************************************/
 
 // Firmware generation flags for this processor
@@ -62,6 +63,10 @@ module FemtoRV32(
    parameter RESET_ADDR       = 32'h00000000;
    parameter ADDR_WIDTH       = 24;
 
+   // Vector configuration.
+   parameter VL_WIDTH         = 2;
+   localparam MAX_VL          = 1 << VL_WIDTH;
+
    /***************************************************************************/
    // Instruction decoding.
    /***************************************************************************/
@@ -71,7 +76,7 @@ module FemtoRV32(
    // https://content.riscv.org/wp-content/uploads/2017/05/riscv-spec-v2.2.pdf
 
    // The destination register
-   wire [4:0] rdId = dstIsVec ? {instr[9:7],vecIdx} : instr[11:7];
+   wire [4:0] rdId = isVectorOp ? {instr[11-VL_WIDTH:7], vecIdx} : instr[11:7];
 
    // The ALU function, decoded in 1-hot form (doing so reduces LUT count)
    // It is used as follows: funct3Is[val] <=> funct3 == val
@@ -99,6 +104,9 @@ module FemtoRV32(
    wire isJAL     =  (instr[6:2] == 5'b11011); // rd <- PC+4; PC<-PC+Jimm
    wire isSYSTEM  =  (instr[6:2] == 5'b11100); // rd <- CSR <- rs1/uimm5
 
+   // The vector extension adds VSETVL.
+   wire isVSETVL  =  (instr[6:2] == 5'b10101); // rd <- VL <- min(rs1, MAX_VL)
+
    wire isALU = isALUimm | isALUreg;
 
    /***************************************************************************/
@@ -110,9 +118,12 @@ module FemtoRV32(
    reg [31:0] registerFile [31:0];
 
    always @(posedge clk) begin
-     if (writeBack)
+     if (writeBack) begin
        if (rdId != 0)
          registerFile[rdId] <= writeBackData;
+       if (isVSETVL)
+         VL <= writeBackData[VL_WIDTH-1:0];
+     end
    end
 
    /***************************************************************************/
@@ -216,14 +227,13 @@ module FemtoRV32(
    reg [62:0] divisor;
    reg [31:0] quotient;
    reg [31:0] quotient_msk;
+   reg        div_sign;  // Registered since aluIn1/2 may change before the
+                         // division iterations are done (for vector division)
 
    wire divstep_do = divisor <= {31'b0, dividend};
 
    wire [31:0] dividendN     = divstep_do ? dividend - divisor[31:0] : dividend;
    wire [31:0] quotientN     = divstep_do ? quotient | quotient_msk  : quotient;
-
-   wire div_sign = ~instr[12] & (instr[13] ? aluIn1[31] : 
-                    (aluIn1[31] != aluIn2[31]) & |aluIn2);
 
    always @(posedge clk) begin
       if (isDivide & aluWr) begin
@@ -231,6 +241,8 @@ module FemtoRV32(
 	 divisor  <= {(~instr[12] & aluIn2[31] ? -aluIn2 : aluIn2), 31'b0};
 	 quotient <= 0;
 	 quotient_msk <= 1 << 31;
+	 div_sign <= ~instr[12] & (instr[13] ? aluIn1[31] :
+	             (aluIn1[31] != aluIn2[31]) & |aluIn2);
       end else begin
 	 dividend     <= dividendN;
 	 divisor      <= divisor >> 1;
@@ -264,7 +276,7 @@ module FemtoRV32(
 
    reg  src1IsVec;           // Source operand 1 is vector?
    reg  src2IsVec;           // Source operand 2 is vector?
-   wire dstIsVec = src1IsVec | src2IsVec;
+   wire isVectorOp = src1IsVec | src2IsVec;
 
    wire [ADDR_WIDTH-1:0] PCplus4 = PC + 4;
 
@@ -297,6 +309,21 @@ module FemtoRV32(
    wire [31:0] CSR_read = sel_cyclesh ? cycles[63:32] : cycles[31:0];
 
    /***************************************************************************/
+   // Vector length register.
+   /***************************************************************************/
+
+   // The size of the VL register is log2(MAX_VL) bits. When VL == 0, it
+   // represents MAX_VL (we do not support zero-cycle vector operations).
+   reg [VL_WIDTH-1:0] VL;
+
+   // This implements the VSETVL logic: rd <- vl <- min(AVL, MAX_VL)
+   // Note: We produce one bit extra compared to the VL register in order to
+   // be able to represent MAX_VL in the VSETVL result.
+   wire [31:0] setvlOut;
+   assign setvlOut[31:VL_WIDTH+1] = 0;
+   assign setvlOut[VL_WIDTH:0] = rs1 < MAX_VL ? rs1[VL_WIDTH:0] : MAX_VL;
+
+   /***************************************************************************/
    // The value written back to the register file.
    /***************************************************************************/
 
@@ -306,7 +333,8 @@ module FemtoRV32(
       (isALU               ? aluOut    : 32'b0) |  // ALUreg, ALUimm
       (isAUIPC             ? PCplusImm : 32'b0) |  // AUIPC
       (isJALR   | isJAL    ? PCplus4   : 32'b0) |  // JAL, JALR
-      (isLoad              ? LOAD_data : 32'b0) ;  // Load
+      (isLoad              ? LOAD_data : 32'b0) |  // Load
+      (isVSETVL            ? setvlOut  : 32'b0) ;  // VSETVL
 
    /* verilator lint_on WIDTH */
 
@@ -409,16 +437,15 @@ module FemtoRV32(
                          PCplus4;
 
    // Vector state.
-   reg [1:0] vecIdx;
-   reg [1:0] vecLen;
-   wire [1:0] vecIdx_new = vecIdx + 1;
-   wire vecOpDone = (vecIdx == vecLen) | !(src1IsVec | src2IsVec);
+   reg [VL_WIDTH-1:0] vecIdx;
+   wire [VL_WIDTH-1:0] vecIdx_new = vecIdx + 1;
+   wire vecElementsPending = isVectorOp & (vecIdx_new != VL);
 
    always @(posedge clk) begin
       if(!reset) begin
          state      <= WAIT_ALU_OR_MEM; // Just waiting for !mem_wbusy
          PC         <= RESET_ADDR[ADDR_WIDTH-1:0];
-         vecLen     <= 2'b00;
+         VL         <= 0;
       end else
 
       // See note [1] at the end of this file.
@@ -430,13 +457,15 @@ module FemtoRV32(
               // Bits 0 and 1 of the instruction word indicate vector mode of the source operands.
               src1IsVec <= !mem_rdata[0];
               src2IsVec <= !mem_rdata[1];
+
+              // Latch source register contents.
               rs1 <= mem_rdata[0] ? registerFile[mem_rdata[19:15]] :
-                                    registerFile[{mem_rdata[17:15],2'b00}];
+                                    registerFile[{mem_rdata[19-VL_WIDTH:15], {VL_WIDTH{1'b0}}}];
               rs2 <= mem_rdata[1] ? registerFile[mem_rdata[24:20]]:
-                                    registerFile[{mem_rdata[22:20],2'b00}];
+                                    registerFile[{mem_rdata[24-VL_WIDTH:20], {VL_WIDTH{1'b0}}}];
 
               // Restart vector element counter.
-              vecIdx <= 2b'00;
+              vecIdx <= 0;
 
               // Latch instruction word.
               instr <= mem_rdata[31:2]; // (see declaration of instr).
@@ -445,20 +474,28 @@ module FemtoRV32(
         end
 
         state[EXECUTE_bit]: begin
-           if(vecOpDone) PC <= PC_new;
+           if (!vecElementsPending)
+              PC <= PC_new;
 
            // Iterate over the source vector registers.
-           rs1 <= registerFile[{instr[17:15],vecIdx_new}];
-           rs2 <= registerFile[{instr[22:20],vecIdx_new}];
+           // TODO(m): We really want to do this when going to EXECUTE, so we do not want to do it
+           // when going to WAIT_ALU_OR_MEM. Instead of having this logic in each state, can we do
+           // it in a single place (wires instead of registers?)?
+           if (src1IsVec)
+              rs1 <= registerFile[{instr[19-VL_WIDTH:15], vecIdx_new}];
+           if (src2IsVec)
+              rs2 <= registerFile[{instr[24-VL_WIDTH:20], vecIdx_new}];
            vecIdx <= vecIdx_new;
 
-           // TODO(m): Handle state transitions for vector operations!
-           state <= needToWait ? WAIT_ALU_OR_MEM : FETCH_INSTR;
+           if (needToWait)
+              state <= WAIT_ALU_OR_MEM;
+           else
+              state <= vecElementsPending ? EXECUTE : FETCH_INSTR;
         end
 
         state[WAIT_ALU_OR_MEM_bit]: begin
-           // TODO(m): Handle state transitions for vector operations!
-           if(!aluBusy & !mem_rbusy & !mem_wbusy) state <= FETCH_INSTR;
+           if(!aluBusy & !mem_rbusy & !mem_wbusy)
+              state <= vecElementsPending ? EXECUTE : FETCH_INSTR;
         end
 
         default: begin // FETCH_INSTR


### PR DESCRIPTION
Here is a draft of my ideas that I came up with yesterday.

## Caveat emptor

Take it for what it is: A sketchbook proof of concept experiment, totally untested. I did not even try to build it, and I am pretty sure that some state transitions will not work properly for certain vector operations.

## Functionality

As described in the code comment, this change tries to:

* Map vector registers on top of the scalar register file.
* Adds the `VSETVL` instruction (from the V extension) to manipulate the vector length (VL) register.
* Adds logic for iterating over the vector register elements while staying in the EXECUTE or EXECUTE+WAIT_ALU_OR_MEM states, until VL vector elements have been processed.

## Instruction encoding

To encode vector instructions, the two least significant bits of the instruction word are used (in RV32I these bits are always `11`, so anything else indicates a vector operation). This is *not* compatible with the C extension, for instance, so some other encoding trick must be used if you want to support that (I am not very versed in RISC-V instruction encoding, but the `CUSTOM_0 - CUSTOM_3` pages could be a possibility).

## Bugs / refactoring

I think that the source register lookup and destination register index (`rdId`) is broken for multi-cycle instructions (load/store/div). Specifically `vecIdx` is not always updated in the right state/cycle.

Furthermore the source register lookup is currently done in two different places (really it needs to be done in three different places IIUIC). It feels like this part can be refactored to solve both the out-of-sync `vecIdx` problem and possibly reduce LUT usage.

## Possible improvements

### More vector registers

The current implementation only provides eight vector registers, of which 3-5 are usable in practice (V0 can never be used, and some scalar registers must be spared for scalar operations). It would be very simple, and valuable, to add more vector registers. All that is required is to double (or quadruple?) the number of scalar registers in `registerFile`. It is mostly a matter of balancing the size of the core (e.g. the number of LUT:s).

### Stride based load/store

Another functionality that I have not added, but that is quite powerful, is support for on-the-fly generation of address strides. I think that a feasible solution would be to add special handling of the case when `src2IsVec = 1` and src2 is an immediate value (e.g. `isLoad | isStore | isALUimm`), such that the immediate value is replaced by an incrementing (registered) value as follows `[0, IMM, 2*IMM, 3*IMM, ...]`.

## Writing programs

This is of course a major problem at the moment. No compiler / toolchain supports the new vector instructions (except for VSETVL).

For prototyping purposes I would personally only write vectorized code directly in assembler language (that also gives better control over scalar register allocation), by first compiling the corresponding scalar code, and then hand-modifing the generated machine code to use the encoding for vector instructions (i.e. modify the 2 LSB:s), and emitting them as `.word` directives.

For instance, the following C code:

```c
void foo(int* dst, const int* src, int num) {
    for (int i = 0; i < num; ++i) {
        dst[i] = src[i];
    }
}
```

...could be implemented in RISC-V assembler with vector instructions (assuming that stride based load/store is supported):

```
foo:
	blez	a2, .L2
.L1:
	vsetvl	a4, a2, zero
	.word	0x0045a381	# lw	v7, +4(a1)
	.word	0x00752221	# sw	v7, +4(a0)
	sub	a2, a2, a4
	addi	a0, a0, 16
	addi	a1, a1, 16
	bnez	a2, .L1
.L2:
	ret
```

As it's far from convenient, in the long run you probably want to patch some toolchain (e.g. binutils/as) to support these instructions to some degree.