### PR TITLE
Add OSX support

### DIFF
--- a/FemtoRV/FIRMWARE/makefile.inc
+++ b/FemtoRV/FIRMWARE/makefile.inc
@@ -21,38 +21,43 @@ show_config:
 
 ################################################################################
 
-# Website to get the RISCV toolchain
-TOOLCHAIN_WEB=https://static.dev.sifive.com/dev-tools
-
-# Version of the RISCV toolchain to get
-#TOOLCHAIN_VER=riscv64-unknown-elf-gcc-20171231-x86_64-linux-centos6
-#TOOLCHAIN_GCC_VER=7.2.0
-TOOLCHAIN_VER=riscv64-unknown-elf-gcc-8.3.0-2020.04.0-x86_64-linux-ubuntu14
-TOOLCHAIN_GCC_VER=8.3.0
-
-RVTOOLCHAIN_DIR=$(FIRMWARE_DIR)/TOOLCHAIN/$(TOOLCHAIN_VER)
-RVTOOLCHAIN_BIN_DIR=$(RVTOOLCHAIN_DIR)/bin
-RVTOOLCHAIN_BIN_PREFIX=riscv64-unknown-elf
-
+uname := $(shell uname)
 uname_m := $(shell uname -m)
 
-ifeq ($(uname_m),aarch64)
-    $(info Configuring for ARM64)
+ifeq ($(uname),Darwin)
+    $(info Configuring for Mac)
     TOOLCHAIN_WEB=https://github.com/xpack-dev-tools/riscv-none-embed-gcc-xpack/releases/download/v10.1.0-1.1
     TOOLCHAIN_VER=xpack-riscv-none-embed-gcc-10.1.0-1.1
-    TOOLCHAIN_DL_SUFFIX=-linux-arm64
+    TOOLCHAIN_DL_SUFFIX=-darwin-x64
     TOOLCHAIN_GCC_VER=10.1.0
     RVTOOLCHAIN_BIN_PREFIX=riscv-none-embed
+else
+    ifeq ($(uname_m),aarch64)
+        $(info Configuring for ARM64)
+        TOOLCHAIN_WEB=https://github.com/xpack-dev-tools/riscv-none-embed-gcc-xpack/releases/download/v10.1.0-1.1
+        TOOLCHAIN_VER=xpack-riscv-none-embed-gcc-10.1.0-1.1
+        TOOLCHAIN_DL_SUFFIX=-linux-arm64
+        TOOLCHAIN_GCC_VER=10.1.0
+        RVTOOLCHAIN_BIN_PREFIX=riscv-none-embed
+    else ifeq ($(uname_m),armv7l)
+        $(info Configuring for Raspberry Pi)
+        TOOLCHAIN_WEB=https://github.com/xpack-dev-tools/riscv-none-embed-gcc-xpack/releases/download/v8.3.0-2.3
+        TOOLCHAIN_VER=xpack-riscv-none-embed-gcc-8.3.0-2.3
+        TOOLCHAIN_DL_SUFFIX=-linux-arm
+        TOOLCHAIN_GCC_VER=8.3.0
+        RVTOOLCHAIN_BIN_PREFIX=riscv-none-embed
+    else
+        $(info Configuring for Linux x86_64)
+        TOOLCHAIN_WEB=https://static.dev.sifive.com/dev-tools
+        TOOLCHAIN_DL_SUFFIX=-x86_64-linux-ubuntu14
+        TOOLCHAIN_VER=riscv64-unknown-elf-gcc-8.3.0-2020.04.0
+        TOOLCHAIN_GCC_VER=8.3.0
+        RVTOOLCHAIN_BIN_PREFIX=riscv64-unknown-elf
+    endif
 endif
 
-ifeq ($(uname_m),armv7l)
-    $(info Configuring for Raspberry Pi)
-    TOOLCHAIN_WEB=https://github.com/xpack-dev-tools/riscv-none-embed-gcc-xpack/releases/download/v8.3.0-2.3
-    TOOLCHAIN_VER=xpack-riscv-none-embed-gcc-8.3.0-2.3
-    TOOLCHAIN_DL_SUFFIX=-linux-arm
-    TOOLCHAIN_GCC_VER=8.3.0
-    RVTOOLCHAIN_BIN_PREFIX=riscv-none-embed
-endif
+RVTOOLCHAIN_DIR=$(FIRMWARE_DIR)/TOOLCHAIN/$(TOOLCHAIN_VER)$(TOOLCHAIN_DL_SUFFIX)
+RVTOOLCHAIN_BIN_DIR=$(RVTOOLCHAIN_DIR)/bin
 
 RVTOOLCHAIN_LIB_DIR=$(RVTOOLCHAIN_DIR)/$(RVTOOLCHAIN_BIN_PREFIX)/lib/$(ARCH)/$(ABI)
 RVTOOLCHAIN_GCC_LIB_DIR=$(RVTOOLCHAIN_DIR)/lib/gcc/$(RVTOOLCHAIN_BIN_PREFIX)/$(TOOLCHAIN_GCC_VER)/$(ARCH)/$(ABI)
@@ -198,7 +203,9 @@ $(RVRANLIB):
 
 get_riscv_toolchain:
 	mkdir -p $(FIRMWARE_DIR)/TOOLCHAIN
-	@echo "Installing RISC-V toolchain in $(FIRMWARE_DIR)/TOOLCHAIN"
+	@echo "Installing RISC-V toolchain for $(uname) $(uname_m) in $(FIRMWARE_DIR)/TOOLCHAIN"
 	(cd $(FIRMWARE_DIR)/TOOLCHAIN; \
-	    wget $(TOOLCHAIN_WEB)/$(TOOLCHAIN_VER)$(TOOLCHAIN_DL_SUFFIX).tar.gz; \
-	    tar xfz $(TOOLCHAIN_VER)$(TOOLCHAIN_DL_SUFFIX).tar.gz)
+	    wget $(TOOLCHAIN_WEB)/$(TOOLCHAIN_VER)$(TOOLCHAIN_DL_SUFFIX).tar.gz -O \
+	        $(TOOLCHAIN_VER)$(TOOLCHAIN_DL_SUFFIX).tar.gz; \
+	    tar xfz $(TOOLCHAIN_VER)$(TOOLCHAIN_DL_SUFFIX).tar.gz; \
+	    mv $(TOOLCHAIN_VER) $(TOOLCHAIN_VER)$(TOOLCHAIN_DL_SUFFIX))

--- a/FemtoRV/TOOLS/make_config.sh
+++ b/FemtoRV/TOOLS/make_config.sh
@@ -1,7 +1,7 @@
 # Extracts compilation flags from selected board, and
 # write them to FIRMWARE/config.mk
 cd RTL
-iverilog -I PROCESSOR $1 get_config.v -o tmp.vvp 
+iverilog -I PROCESSOR $1 -o tmp.vvp get_config.v
 vvp tmp.vvp > ../FIRMWARE/config.mk
 rm -f tmp.vvp
 echo BOARD=$BOARD >> ../FIRMWARE/config.mk


### PR DESCRIPTION
This also allows multiple toolchains to co-exist, by adding the 'suffix' to the expected path.

Tested on OSX M1 (but downloading x64 binaries since arm binaries for darwin don't exist), as well as Linux AARCH64.

Needs to be tested on raspberry pi and on Linux x64. If you build anything you'll download a new copy of the toolchain since it won't recognize the old directory.

I also fixed a bug that occurs when running newer versions of `iverilog`: Newer versions seem to be more picky about arg order.