### PR TITLE
Fixed error in riscv_assembly.v

### DIFF
--- a/FemtoRV/TUTORIALS/FROM_BLINKER_TO_RISCV/riscv_assembly.v
+++ b/FemtoRV/TUTORIALS/FROM_BLINKER_TO_RISCV/riscv_assembly.v
@@ -132,7 +132,7 @@ task SRA;
    input [4:0] rd;
    input [4:0] rs1;
    input [4:0] rs2;
-   RType(7'b0110011, rd, rs1, rs2, 3'b101, 7'b0000010);
+   RType(7'b0110011, rd, rs1, rs2, 3'b101, 7'b0100000);
 endtask
 
 task OR;


### PR DESCRIPTION
The funct7 value for SRA in learn-fpga/FemtoRV/TUTORIALS/FROM_BLINKER_TO_RISCV/riscv_assembly.v
was 0b0000010 and should be 0b0100000