### PR TITLE
Gowin. Switch to nextpnr-himbaechel.

### DIFF
--- a/FemtoRV/TUTORIALS/FROM_BLINKER_TO_RISCV/BOARDS/run_tangnano9k.sh
+++ b/FemtoRV/TUTORIALS/FROM_BLINKER_TO_RISCV/BOARDS/run_tangnano9k.sh
@@ -8,6 +8,6 @@ FPGA_DEVICE=GW1NR-LV9QN88PC6/I5
 VERILOGS=$1
 
 $FPGA_ROOT/yosys -q -DTANGNANO9K -DBOARD_FREQ=$BOARD_FREQ -DCPU_FREQ=$CPU_FREQ -p "synth_gowin -top $PROJECTNAME -json $PROJECTNAME.json" $VERILOGS  || exit
-$FPGA_ROOT/nextpnr-gowin --force --timing-allow-fail --json $PROJECTNAME.json --cst BOARDS/$BOARD.cst --write pnr_$PROJECTNAME.json --device $FPGA_DEVICE --family $FPGA_FAMILY || exit
+$FPGA_ROOT/nextpnr-himbaechel --force --timing-allow-fail --json $PROJECTNAME.json --vopt cst=BOARDS/$BOARD.cst --write pnr_$PROJECTNAME.json --device $FPGA_DEVICE --vopt family=$FPGA_FAMILY || exit
 $FPGA_ROOT/gowin_pack -d $FPGA_FAMILY -o $PROJECTNAME.fs pnr_$PROJECTNAME.json || exit
 $FPGA_ROOT/openFPGALoader -b $BOARD $PROJECTNAME.fs


### PR DESCRIPTION
nextpnr-gowin was a test bed that began to experience difficulties supporting chips with a large number of LUT/DFFs, so a transition was made to the new Himbaechel architecture for routing.